### PR TITLE
Fix main_k5.yml workflow build and release failures

### DIFF
--- a/.github/workflows/main_k5.yml
+++ b/.github/workflows/main_k5.yml
@@ -76,29 +76,20 @@ jobs:
           PLATFORM=${{ matrix.platform }}
           VERSION=${{ matrix.version }}
           TOOLKIT_VER=${VERSION}
-          DIR=${VERSION}
-          
-          # 소스 디렉토리가 없으면 스킵
-          [ ! -d "${ROOT_PATH}/${DIR}" ] && echo "No source dir ${DIR}, skipping." && exit 0
 
           mkdir -p "/tmp/${PLATFORM}-${VERSION}"
 
-          # dante90/syno-compiler 도커 이미지로 모듈 컴파일
           docker run --privileged -u $(id -u) --rm -t \
-            -v "${ROOT_PATH}":/input \          # ← DIR 없이 루트 직접 마운트
-            -v "${ROOT_PATH}/${DIR}":/input \
+            -v "${ROOT_PATH}":/input \
             -v "/tmp/${PLATFORM}-${VERSION}":/output \
             dante90/syno-compiler:${TOOLKIT_VER} compile-module ${PLATFORM}
 
-          # 컴파일 결과물 정리: pats 원본 모듈 우선, 없으면 컴파일본 사용
           for M in $(ls /tmp/${PLATFORM}-${VERSION}); do
             PLATFORM_DIR="${PLATFORM}-${TOOLKIT_VER}-${VERSION}"
             mkdir -p "${ROOT_PATH}/source/output/${PLATFORM_DIR}"
             if [ -f ~/src/pats/modules/${PLATFORM}/$M ]; then
-              # original
               cp ~/src/pats/modules/${PLATFORM}/$M "${ROOT_PATH}/source/output/${PLATFORM_DIR}/"
             else
-              # compiled
               cp /tmp/${PLATFORM}-${VERSION}/$M "${ROOT_PATH}/source/output/${PLATFORM_DIR}/"
             fi
           done
@@ -159,6 +150,7 @@ jobs:
           if [ -n "${VERSION}" ]; then
             echo "Version: ${VERSION}"
             echo "${VERSION}" >VERSION
+            mkdir -p "./rp-lkms"
             echo "${VERSION}" >"./rp-lkms/VERSION"
             echo "VERSION=${VERSION}" >> $GITHUB_ENV
           fi
@@ -166,7 +158,7 @@ jobs:
       - name: Zip Lkms
         if: env.VERSION != ''
         run: |
-          zip -9 rp-lkms.zip -j rp-lkms/*
+          zip -9 -r -j rp-lkms.zip rp-lkms/
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
- **Fix docker mount**: Remove inline comment that broke `\` line continuation and duplicate `/input` mount. Mount repo root directly as `/input` so the compiler can find the LKM source code.
- **Remove broken DIR check**: `DIR=${VERSION}` resolved to `7.1`, `7.2`, `7.3` — directories that don't exist — causing all build jobs to skip with no artifacts produced.
- **Fix release job**: Add `mkdir -p ./rp-lkms` before writing `VERSION` file to prevent `No such file or directory` error.
- **Fix zip command**: Add `-r` flag to recurse into artifact subdirectories.

## Test plan
- [ ] Run the `Build lkms mshell with toolchain dockerhub` workflow via `workflow_dispatch`
- [ ] Verify all build matrix jobs compile successfully (no "No source dir" skip)
- [ ] Verify artifacts are uploaded and the release job completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)