### PR TITLE
Pass RP_MODULE_TARGET env vars to fix compile error

### DIFF
--- a/.github/workflows/main_k5.yml
+++ b/.github/workflows/main_k5.yml
@@ -61,12 +61,17 @@ jobs:
           ROOT_PATH=${{ github.workspace }}
           VERSION=${{ matrix.version }}
           TOOLKIT_VER=${VERSION}
+          PARM="${{ matrix.parm }}"
+          RP_TARGET="${PARM%%-*}"
+          RP_TARGET_VER="${PARM##*v}"
 
           for PLATFORM in ${{ matrix.platforms }}; do
-            echo "=== Compiling for ${PLATFORM} (DSM ${VERSION}) ==="
+            echo "=== Compiling for ${PLATFORM} (DSM ${VERSION}, target=${RP_TARGET}, ver=${RP_TARGET_VER}) ==="
             mkdir -p "/tmp/${PLATFORM}-${VERSION}"
 
             docker run --privileged --rm -t \
+              -e RP_MODULE_TARGET="${RP_TARGET}" \
+              -e RP_MODULE_TARGET_VER="${RP_TARGET_VER}" \
               -v "${ROOT_PATH}":/input \
               -v "/tmp/${PLATFORM}-${VERSION}":/output \
               dante90/syno-compiler:${TOOLKIT_VER} compile-module ${PLATFORM}


### PR DESCRIPTION
## Summary
- **Fix compile error**: The Makefile intentionally fails with `--bogus-flag-which-should-not-be-called-NO_RP_MODULE_TARGER_SPECIFIED` when `RP_MODULE_TARGET` is undefined.
- Extract target and version from matrix `parm` field (e.g. `prod-v7` → `RP_MODULE_TARGET=prod`, `RP_MODULE_TARGET_VER=7`) and pass them as `-e` environment variables to the docker container.

## Test plan
- [ ] Run `Build lkms mshell with toolchain dockerhub` workflow via `workflow_dispatch`
- [ ] Verify the bogus flag error no longer appears
- [ ] Verify modules compile successfully for all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)