### PR TITLE
Fix output dir permission denied in docker compile

### DIFF
--- a/.github/workflows/main_k5.yml
+++ b/.github/workflows/main_k5.yml
@@ -68,6 +68,7 @@ jobs:
           for PLATFORM in ${{ matrix.platforms }}; do
             echo "=== Compiling for ${PLATFORM} (DSM ${VERSION}, target=${RP_TARGET}, ver=${RP_TARGET_VER}) ==="
             mkdir -p "/tmp/${PLATFORM}-${VERSION}"
+            chmod 777 "/tmp/${PLATFORM}-${VERSION}"
 
             docker run --privileged --rm -t \
               -e RP_MODULE_TARGET="${RP_TARGET}" \


### PR DESCRIPTION
## Summary
- Compilation succeeds (`redpill.ko` is built) but the container's `compile-module` script fails with `cp: cannot create regular file '/output/redpill.ko': Permission denied` when copying the result to the mounted output directory.
- Fix: `chmod 777` on the host output directory before mounting it into the container, so any UID inside the container can write to it.

## Test plan
- [ ] Run `Build lkms mshell with toolchain dockerhub` workflow via `workflow_dispatch`
- [ ] Verify `redpill.ko` is copied to output without permission errors
- [ ] Verify artifacts are uploaded and release job completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)