### PR TITLE
Cache docker images to avoid repeated downloads

### DIFF
--- a/.github/workflows/main_k5.yml
+++ b/.github/workflows/main_k5.yml
@@ -52,9 +52,23 @@ jobs:
           git config --global user.name "github-actions[bot]"
           sudo timedatectl set-timezone "Asia/Seoul"
 
-      - name: Pull Docker Image
+      - name: Cache Docker Image
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/docker-image-${{ matrix.version }}.tar
+          key: docker-syno-compiler-${{ matrix.version }}
+
+      - name: Load or Pull Docker Image
         run: |
-          docker pull dante90/syno-compiler:${{ matrix.version }}
+          if [ -f /tmp/docker-image-${{ matrix.version }}.tar ]; then
+            echo "Loading cached image..."
+            docker load < /tmp/docker-image-${{ matrix.version }}.tar
+          else
+            echo "Pulling image from registry..."
+            docker pull dante90/syno-compiler:${{ matrix.version }}
+            docker save dante90/syno-compiler:${{ matrix.version }} > /tmp/docker-image-${{ matrix.version }}.tar
+          fi
 
       - name: Compile LKMs via Docker (dante90/syno-compiler)
         run: |


### PR DESCRIPTION
## Summary
- Each workflow run downloads ~2.9GB docker images from scratch, wasting time and bandwidth on repeated/failed builds.
- Use `actions/cache@v4` to save docker images as tarballs after the first pull. Subsequent runs load from cache via `docker load`, skipping the download entirely.

### How it works
| Run | Behavior |
|-----|----------|
| 1st run | `docker pull` → `docker save` to cache (~2.9GB per version) |
| 2nd+ runs | `docker load` from cache (local disk, much faster) |

GitHub Actions cache has a 10GB limit per repo. With 3 images (~2.9GB each ≈ 8.7GB total), this fits within the limit.

## Test plan
- [ ] First run: verify images are pulled and cached
- [ ] Second run: verify cache hit and `docker load` is used instead of `docker pull`
- [ ] Verify compile and release jobs complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)